### PR TITLE
content: 1.2.8

### DIFF
--- a/app_data/assets/contents.json
+++ b/app_data/assets/contents.json
@@ -274,5 +274,13 @@
   "pdf/programme_details.pdf": {
     "md5Checksum": "d7f88e6bc4851b986b223a9b536e0e18",
     "size_kb": 123
+  },
+  "videos/add_parent.mp4": {
+    "md5Checksum": "2cdc77cf24738d4dd9a8572bb834cc32",
+    "size_kb": 19312.7
+  },
+  "videos/onboard_caregivers.mp4": {
+    "md5Checksum": "06a87076d38ddaac71e27e9e58b52b96",
+    "size_kb": 91291.6
   }
 }

--- a/app_data/sheets/contents.json
+++ b/app_data/sheets/contents.json
@@ -317,6 +317,11 @@
       "flow_name": "exit_dev_mode",
       "_xlsxPath": "templates/app_menu.xlsx"
     },
+    "external_form": {
+      "flow_type": "template",
+      "flow_name": "external_form",
+      "_xlsxPath": "templates/data_collection.xlsx"
+    },
     "feature_feedback_debug": {
       "flow_type": "template",
       "flow_name": "feature_feedback_debug",

--- a/app_data/sheets/data_list/about_this_app.json
+++ b/app_data/sheets/data_list/about_this_app.json
@@ -6,15 +6,13 @@
   "rows": [
     {
       "id": "text_1",
-      "text": "@global.app_name is an app designed by IDEMS International and Parenting for Lifelong Health to support the scale up of Crianza con Conciencia+ in Mexico. The content herein is available under an open source Creative Commons International 4.0 license. It was developed in collaboration with key partners:",
+      "text": "@global.app_name is an app designed by IDEMS International and Parenting for Lifelong Health to support the scale up of Crianza con Conciencia + in Mexico. The content herein is available under an open source Creative Commons International 4.0 license. It was developed in collaboration with key partners:",
       "_translations": {
-        "text": {
-          "mx_es": true
-        }
+        "text": {}
       },
       "_translatedFields": {
         "text": {
-          "eng": "@global.app_name is an app designed by IDEMS International and Parenting for Lifelong Health to support the scale up of Crianza con Conciencia+ in Mexico. The content herein is available under an open source Creative Commons International 4.0 license. It was developed in collaboration with key partners:"
+          "eng": "@global.app_name is an app designed by IDEMS International and Parenting for Lifelong Health to support the scale up of Crianza con Conciencia + in Mexico. The content herein is available under an open source Creative Commons International 4.0 license. It was developed in collaboration with key partners:"
         }
       }
     }

--- a/app_data/sheets/data_list/report_data.json
+++ b/app_data/sheets/data_list/report_data.json
@@ -104,6 +104,27 @@
           "eng": "Week 4: Building Pleasant Emotions"
         }
       }
+    },
+    {
+      "id": "test",
+      "type": "external",
+      "tag_list": [
+        "study_dif_bc",
+        "study_dif_chih",
+        "study_dif_cdmx",
+        "study_dif_mich",
+        "scale_dif"
+      ],
+      "external_url": "https://www.idems.international/",
+      "name": "Test",
+      "_translations": {
+        "name": {}
+      },
+      "_translatedFields": {
+        "name": {
+          "eng": "Test"
+        }
+      }
     }
   ],
   "_xlsxPath": "data/FacilitatorApp MX content.xlsx"

--- a/app_data/sheets/data_list/report_data.json
+++ b/app_data/sheets/data_list/report_data.json
@@ -115,7 +115,7 @@
         "study_dif_mich",
         "scale_dif"
       ],
-      "external_url": "https://www.idems.international/",
+      "external_url": "www.idems.international/",
       "name": "Test",
       "_translations": {
         "name": {}

--- a/app_data/sheets/data_list/report_data.json
+++ b/app_data/sheets/data_list/report_data.json
@@ -104,27 +104,6 @@
           "eng": "Week 4: Building Pleasant Emotions"
         }
       }
-    },
-    {
-      "id": "test",
-      "type": "external",
-      "tag_list": [
-        "study_dif_bc",
-        "study_dif_chih",
-        "study_dif_cdmx",
-        "study_dif_mich",
-        "scale_dif"
-      ],
-      "external_url": "www.idems.international/",
-      "name": "Test",
-      "_translations": {
-        "name": {}
-      },
-      "_translatedFields": {
-        "name": {
-          "eng": "Test"
-        }
-      }
     }
   ],
   "_xlsxPath": "data/FacilitatorApp MX content.xlsx"

--- a/app_data/sheets/template/data_collection.json
+++ b/app_data/sheets/template/data_collection.json
@@ -376,7 +376,6 @@
       "_translations": {
         "value": {}
       },
-      "condition": false,
       "exclude_from_translation": true,
       "_nested_name": "debug_has_virtual",
       "_dynamicFields": {
@@ -455,7 +454,6 @@
       "_translations": {
         "value": {}
       },
-      "condition": false,
       "exclude_from_translation": true,
       "_nested_name": "debug_has_in_person",
       "_dynamicFields": {
@@ -470,6 +468,84 @@
       },
       "_dynamicDependencies": {
         "@local.has_in_person": [
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "external",
+      "value": "external",
+      "_translations": {
+        "value": {}
+      },
+      "exclude_from_translation": true,
+      "type": "set_variable",
+      "_nested_name": "external"
+    },
+    {
+      "name": "has_external",
+      "value": "@calc(@local.relevant_form_type_list.includes(@local.external))",
+      "_translations": {
+        "value": {}
+      },
+      "exclude_from_translation": true,
+      "type": "set_variable",
+      "_nested_name": "has_external",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@calc(@local.relevant_form_type_list.includes(@local.external))",
+            "matchedExpression": "@local.relevant_form_type_list.includes",
+            "type": "local",
+            "fieldName": "relevant_form_type_list"
+          },
+          {
+            "fullExpression": "@calc(@local.relevant_form_type_list.includes(@local.external))",
+            "matchedExpression": "@local.external",
+            "type": "local",
+            "fieldName": "external"
+          },
+          {
+            "fullExpression": "@calc(@local.relevant_form_type_list.includes(@local.external))",
+            "matchedExpression": "@calc(@local.relevant_form_type_list.includes(@local.external))",
+            "type": "calc",
+            "fieldName": "@local.relevant_form_type_list.includes(@local.external)"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.relevant_form_type_list.includes": [
+          "value"
+        ],
+        "@local.external": [
+          "value"
+        ],
+        "@calc(@local.relevant_form_type_list.includes(@local.external))": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "name": "debug_has_external",
+      "value": "@local.has_external",
+      "_translations": {
+        "value": {}
+      },
+      "exclude_from_translation": true,
+      "_nested_name": "debug_has_external",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@local.has_external",
+            "matchedExpression": "@local.has_external",
+            "type": "local",
+            "fieldName": "has_external"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.has_external": [
           "value"
         ]
       }
@@ -635,6 +711,45 @@
         }
       ],
       "_nested_name": "dg_type"
+    },
+    {
+      "type": "button",
+      "name": "button_external",
+      "value": "Reflection for Coaching",
+      "_translations": {
+        "value": {}
+      },
+      "action_list": [
+        {
+          "trigger": "click",
+          "action_id": "pop_up",
+          "args": [
+            "external_form"
+          ],
+          "_raw": "click | pop_up: external_form",
+          "_cleaned": "click | pop_up: external_form"
+        }
+      ],
+      "parameter_list": {
+        "style": "card"
+      },
+      "condition": "@local.has_external",
+      "_nested_name": "button_external",
+      "_dynamicFields": {
+        "condition": [
+          {
+            "fullExpression": "@local.has_external",
+            "matchedExpression": "@local.has_external",
+            "type": "local",
+            "fieldName": "has_external"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.has_external": [
+          "condition"
+        ]
+      }
     },
     {
       "name": "attendance_data_json",

--- a/app_data/sheets/template/data_collection.json
+++ b/app_data/sheets/template/data_collection.json
@@ -376,6 +376,7 @@
       "_translations": {
         "value": {}
       },
+      "condition": false,
       "exclude_from_translation": true,
       "_nested_name": "debug_has_virtual",
       "_dynamicFields": {
@@ -454,6 +455,7 @@
       "_translations": {
         "value": {}
       },
+      "condition": false,
       "exclude_from_translation": true,
       "_nested_name": "debug_has_in_person",
       "_dynamicFields": {
@@ -532,6 +534,7 @@
       "_translations": {
         "value": {}
       },
+      "condition": false,
       "exclude_from_translation": true,
       "_nested_name": "debug_has_external",
       "_dynamicFields": {

--- a/app_data/sheets/template/external_form.json
+++ b/app_data/sheets/template/external_form.json
@@ -1,0 +1,243 @@
+{
+  "flow_type": "template",
+  "flow_name": "external_form",
+  "status": "released",
+  "rows": [
+    {
+      "type": "title",
+      "name": "title",
+      "value": "Reflection for Coaching",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "title"
+    },
+    {
+      "type": "text",
+      "name": "question_text",
+      "value": "Which session are you reporting on?",
+      "_translations": {
+        "value": {
+          "mx_es": true
+        }
+      },
+      "_nested_name": "question_text"
+    },
+    {
+      "type": "items",
+      "value": "@data.report",
+      "exclude_from_translation": true,
+      "rows": [
+        {
+          "name": "is_relevant_form",
+          "value": "@calc(@item.tag_list.includes(@fields.current_package))",
+          "_translations": {
+            "value": {}
+          },
+          "condition": "@global.has_multiple_content_packages",
+          "type": "set_variable",
+          "_nested_name": "items_4.is_relevant_form",
+          "_dynamicFields": {
+            "value": [
+              {
+                "fullExpression": "@calc(@item.tag_list.includes(@fields.current_package))",
+                "matchedExpression": "@item.tag_list.includes",
+                "type": "item",
+                "fieldName": "tag_list"
+              },
+              {
+                "fullExpression": "@calc(@item.tag_list.includes(@fields.current_package))",
+                "matchedExpression": "@fields.current_package",
+                "type": "fields",
+                "fieldName": "current_package"
+              },
+              {
+                "fullExpression": "@calc(@item.tag_list.includes(@fields.current_package))",
+                "matchedExpression": "@calc(@item.tag_list.includes(@fields.current_package))",
+                "type": "calc",
+                "fieldName": "@item.tag_list.includes(@fields.current_package)"
+              }
+            ],
+            "condition": [
+              {
+                "fullExpression": "@global.has_multiple_content_packages",
+                "matchedExpression": "@global.has_multiple_content_packages",
+                "type": "global",
+                "fieldName": "has_multiple_content_packages"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.tag_list.includes": [
+              "value"
+            ],
+            "@fields.current_package": [
+              "value"
+            ],
+            "@calc(@item.tag_list.includes(@fields.current_package))": [
+              "value"
+            ],
+            "@global.has_multiple_content_packages": [
+              "condition"
+            ]
+          }
+        },
+        {
+          "name": "is_relevant_form",
+          "value": true,
+          "condition": "!@global.has_multiple_content_packages",
+          "type": "set_variable",
+          "_nested_name": "items_4.is_relevant_form",
+          "_dynamicFields": {
+            "condition": [
+              {
+                "fullExpression": "!@global.has_multiple_content_packages",
+                "matchedExpression": "!@global.has_multiple_content_packages",
+                "type": "global",
+                "fieldName": "has_multiple_content_packages"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "!@global.has_multiple_content_packages": [
+              "condition"
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "name": "button_@item.id",
+          "value": "@item.name",
+          "_translations": {
+            "value": {}
+          },
+          "action_list": [
+            {
+              "trigger": "click",
+              "action_id": "go_to_url",
+              "args": [
+                "@item.external_url"
+              ],
+              "_raw": "click | go_to_url: @item.external_url",
+              "_cleaned": "click | go_to_url: @item.external_url"
+            }
+          ],
+          "parameter_list": {
+            "style": "card"
+          },
+          "condition": "@item.type == \"external\" & @local.is_relevant_form",
+          "exclude_from_translation": true,
+          "_nested_name": "items_4.button_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "button_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "@item.name",
+                "matchedExpression": "@item.name",
+                "type": "item",
+                "fieldName": "name"
+              }
+            ],
+            "action_list": {
+              "0": {
+                "args": {
+                  "0": [
+                    {
+                      "fullExpression": "@item.external_url",
+                      "matchedExpression": "@item.external_url",
+                      "type": "item",
+                      "fieldName": "external_url"
+                    }
+                  ]
+                },
+                "_raw": [
+                  {
+                    "fullExpression": "click | go_to_url: @item.external_url",
+                    "matchedExpression": "@item.external_url",
+                    "type": "item",
+                    "fieldName": "external_url"
+                  }
+                ],
+                "_cleaned": [
+                  {
+                    "fullExpression": "click | go_to_url: @item.external_url",
+                    "matchedExpression": "@item.external_url",
+                    "type": "item",
+                    "fieldName": "external_url"
+                  }
+                ]
+              }
+            },
+            "condition": [
+              {
+                "fullExpression": "@item.type == \"external\" & @local.is_relevant_form",
+                "matchedExpression": "@item.type",
+                "type": "item",
+                "fieldName": "type"
+              },
+              {
+                "fullExpression": "@item.type == \"external\" & @local.is_relevant_form",
+                "matchedExpression": "@local.is_relevant_form",
+                "type": "local",
+                "fieldName": "is_relevant_form"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "items_4.button_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "_nested_name"
+            ],
+            "@item.name": [
+              "value"
+            ],
+            "@item.external_url": [
+              "action_list.0.args.0",
+              "action_list.0._raw",
+              "action_list.0._cleaned"
+            ],
+            "@item.type": [
+              "condition"
+            ],
+            "@local.is_relevant_form": [
+              "condition"
+            ]
+          }
+        }
+      ],
+      "name": "items_4",
+      "_nested_name": "items_4",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.report",
+            "matchedExpression": "@data.report",
+            "type": "data",
+            "fieldName": "report"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@data.report": [
+          "value"
+        ]
+      }
+    }
+  ],
+  "_xlsxPath": "templates/data_collection.xlsx"
+}

--- a/config.ts
+++ b/config.ts
@@ -6,7 +6,7 @@ config.google_drive.assets_folder_ids = ["1KcHDI7O4o2_FZ_YlXsz-8OqN3ehsfdVf", "1
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/plh-facilitator-app-mx-content.git",
-  content_tag_latest: "1.2.7",
+  content_tag_latest: "1.2.8",
 };
 
 config.android = {


### PR DESCRIPTION
This adds a new form type, `external`, as an option to the `report` data list. External forms need a title and a url (which does not contain `https://`, simply start with `www.` (because of [this code issue](https://github.com/IDEMSInternational/open-app-builder/issues/1706)). The external forms appear under the header "Reflection for Coaching" on the data collection page. 

Report data list:
![image](https://github.com/IDEMSInternational/plh-facilitator-app-mx-content/assets/74557272/5043c32e-07ad-4698-ad82-59a14749c8cb)

[Screenity video - Jun 21, 2024.webm](https://github.com/IDEMSInternational/plh-facilitator-app-mx-content/assets/74557272/f23adb8a-0e6f-4b3b-bd7c-cf0c9b6734e8)

Closes #58 